### PR TITLE
feat: タスク READ API を実装 (#1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# TaskManagement — Claude Code ルール
+
+## 命名規則（Conventional Commits ベース）
+
+すべての命名で以下の `type` を統一して使う。
+
+| type | 用途 |
+|------|------|
+| `feat` | 新機能追加 |
+| `fix` | バグ修正 |
+| `docs` | ドキュメント更新 |
+| `refactor` | リファクタリング |
+| `chore` | 設定変更・依存関係更新 |
+| `test` | テスト追加・修正 |
+
+### イシュータイトル
+
+```
+<type>: <作業の概要>
+```
+
+例:
+```
+feat: タスク一覧取得APIの実装
+fix: ログイン時にエラーが発生する問題
+docs: データベース設計書の作成
+```
+
+### ブランチ名
+
+```
+<type>/issue-<番号>-<短い説明（英語）>
+```
+
+例:
+```
+feat/issue-3-add-task-api
+fix/issue-7-fix-login-error
+docs/issue-12-update-readme
+```
+
+### コミットメッセージ
+
+```
+<type>: <変更内容の概要>
+```
+
+例:
+```
+feat: タスク一覧APIを追加
+fix: ログイン時のエラーを修正
+docs: READMEを更新
+```
+
+### プルリクエストタイトル
+
+```
+<type>: <作業の概要> (#<イシュー番号>)
+```
+
+例:
+```
+feat: タスク一覧取得APIを追加 (#3)
+fix: ログイン時のエラーを修正 (#7)
+```
+
+---
+
+## GitHub ワークフロー（必ず守ること）
+
+### 1. 作業開始前に必ずイシューを作る
+
+```bash
+gh issue create --title "<type>: <作業の概要>" --body "<詳細説明>" --label "<ラベル>"
+```
+
+- イシューなしで作業を開始してはならない
+
+### 2. ブランチを作る
+
+```bash
+git checkout -b <type>/issue-<番号>-<説明>
+```
+
+### 3. main への直接プッシュ禁止
+
+- `main` ブランチへの直接コミット・プッシュは禁止（GitHub 側でも保護設定済み）
+- 作業は必ずフィーチャーブランチで行い、プルリクエスト経由でマージする
+
+### 4. プルリクエストのルール
+
+- PR 本文に `Closes #<イシュー番号>` を必ず記載する
+
+```bash
+gh pr create --title "<type>: <概要> (#<番号>)" --body "Closes #<番号>"
+```
+
+### 5. 作業の流れまとめ
+
+```
+1. gh issue create でイシュー作成
+2. git checkout -b <type>/issue-<番号>-<説明> でブランチ作成
+3. 作業・コミット（Conventional Commits 形式）
+4. gh pr create でプルリクエスト作成
+5. マージ後にブランチ削除
+```
+
+---
+
+## プロジェクト概要
+
+- **コース**: RaiseTech AI エンジニアコース 第3回
+- **言語**: Java（Spring Boot 4.x）
+- **DB**: PostgreSQL（Docker）

--- a/backend/src/main/java/com/raisetech/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/controller/TaskController.java
@@ -1,0 +1,37 @@
+package com.raisetech.taskmanagement.controller;
+
+import com.raisetech.taskmanagement.entity.Task;
+import com.raisetech.taskmanagement.service.TaskService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskController {
+
+    private final TaskService taskService;
+
+    public TaskController(TaskService taskService) {
+        this.taskService = taskService;
+    }
+
+    @GetMapping
+    public List<Task> getTasks(
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String priority) {
+        return taskService.findTasks(status, priority);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Task> getTaskById(@PathVariable Long id) {
+        return taskService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/backend/src/main/java/com/raisetech/taskmanagement/repository/TaskRepository.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/repository/TaskRepository.java
@@ -3,5 +3,12 @@ package com.raisetech.taskmanagement.repository;
 import com.raisetech.taskmanagement.entity.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findByStatus(String status);
+
+    List<Task> findByPriority(String priority);
+
+    List<Task> findByStatusAndPriority(String status, String priority);
 }

--- a/backend/src/main/java/com/raisetech/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/service/TaskService.java
@@ -1,0 +1,34 @@
+package com.raisetech.taskmanagement.service;
+
+import com.raisetech.taskmanagement.entity.Task;
+import com.raisetech.taskmanagement.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class TaskService {
+
+    private final TaskRepository taskRepository;
+
+    public TaskService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    public List<Task> findTasks(String status, String priority) {
+        if (status != null && priority != null) {
+            return taskRepository.findByStatusAndPriority(status, priority);
+        } else if (status != null) {
+            return taskRepository.findByStatus(status);
+        } else if (priority != null) {
+            return taskRepository.findByPriority(priority);
+        } else {
+            return taskRepository.findAll();
+        }
+    }
+
+    public Optional<Task> findById(Long id) {
+        return taskRepository.findById(id);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,7 +10,11 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+    defer-datasource-initialization: true
     properties:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  sql:
+    init:
+      mode: always

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,0 +1,11 @@
+-- 学習用: 起動毎にデータをリセットして投入（本番ではやらない）
+TRUNCATE TABLE tasks RESTART IDENTITY;
+
+INSERT INTO tasks (title, description, priority, status, position, due_date, created_at, updated_at) VALUES
+('要件定義書のレビュー',       '第3回課題のスコープを確認',         'high',   'doing', 1, '2026-04-28', '2026-04-20 09:00:00', '2026-04-20 09:00:00'),
+('PostgreSQL Docker 起動確認', 'docker compose up -d で接続確認',   'medium', 'done',  2, '2026-04-22', '2026-04-21 10:30:00', '2026-04-22 18:00:00'),
+('Task エンティティ実装',      'JPA アノテーションを付与',          'high',   'done',  3, '2026-04-23', '2026-04-22 11:00:00', '2026-04-23 17:00:00'),
+('READ API の実装',           'Controller/Service/Repository',     'high',   'todo',  4, '2026-04-26', '2026-04-25 09:00:00', '2026-04-25 09:00:00'),
+('curl で動作確認',            'GET /api/tasks のレスポンス確認',   'medium', 'todo',  5, '2026-04-26', '2026-04-25 09:30:00', '2026-04-25 09:30:00'),
+('CREATE API の設計',         'POST /api/tasks の要件整理',        'low',    'todo',  6, '2026-04-30', '2026-04-25 10:00:00', '2026-04-25 10:00:00'),
+('週次振り返りの提出',         'RaiseTech 第3回の課題提出',         'medium', 'todo',  7, '2026-04-27', '2026-04-25 10:30:00', '2026-04-25 10:30:00');


### PR DESCRIPTION
## 概要

タスクの取得（READ）API を実装しました。DB にテストデータを仕込んで、curl で JSON が返ってくることを確認済みです。

## 実装内容

### 新規作成
- `TaskController.java` — `GET /api/tasks`, `GET /api/tasks/{id}`, `GET /api/tasks?status&priority` の3エンドポイント
- `TaskService.java` — 絞り込み条件の組み合わせ分岐ロジック
- `data.sql` — 起動時に自動投入されるテストデータ（7件、起動毎にリセット）

### 編集
- `TaskRepository.java` — `findByStatus`, `findByPriority`, `findByStatusAndPriority` の派生クエリを追加
- `application.yml` — `defer-datasource-initialization: true` と `sql.init.mode: always` を追記

## 動作確認

```bash
# 全件取得 → 7件の JSON 配列
curl -s http://localhost:8080/api/tasks | jq

# 1件取得
curl -s http://localhost:8080/api/tasks/1 | jq

# 存在しない ID → HTTP 404
curl -i http://localhost:8080/api/tasks/9999

# status で絞り込み → todo 4件
curl -s "http://localhost:8080/api/tasks?status=todo" | jq

# AND 検索 → todo かつ high 1件
curl -s "http://localhost:8080/api/tasks?status=todo&priority=high" | jq
```

Closes #1