### PR TITLE
feat: タスク登録APIと登録UIを追加 (#7)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/src/main/java/com/raisetech/taskmanagement/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/config/WebMvcConfig.java
@@ -11,6 +11,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
                 .allowedOrigins("http://localhost:5173")
-                .allowedMethods("GET");
+                .allowedMethods("GET", "POST");
     }
 }

--- a/backend/src/main/java/com/raisetech/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/controller/TaskController.java
@@ -1,10 +1,15 @@
 package com.raisetech.taskmanagement.controller;
 
+import com.raisetech.taskmanagement.dto.CreateTaskRequest;
 import com.raisetech.taskmanagement.entity.Task;
 import com.raisetech.taskmanagement.service.TaskService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,5 +38,11 @@ public class TaskController {
         return taskService.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Task> createTask(@Valid @RequestBody CreateTaskRequest request) {
+        Task created = taskService.createTask(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 }

--- a/backend/src/main/java/com/raisetech/taskmanagement/dto/CreateTaskRequest.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/dto/CreateTaskRequest.java
@@ -1,0 +1,58 @@
+package com.raisetech.taskmanagement.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+public class CreateTaskRequest {
+
+    @NotBlank(message = "title は必須です")
+    private String title;
+
+    private String description;
+
+    private String priority;
+
+    private String status;
+
+    private LocalDate dueDate;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
+    }
+}

--- a/backend/src/main/java/com/raisetech/taskmanagement/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/exception/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.raisetech.taskmanagement.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException ex) {
+        Map<String, String> fieldErrors = new HashMap<>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            fieldErrors.put(error.getField(), error.getDefaultMessage());
+        }
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", "リクエストが不正です");
+        body.put("errors", fieldErrors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+}

--- a/backend/src/main/java/com/raisetech/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/service/TaskService.java
@@ -1,10 +1,13 @@
 package com.raisetech.taskmanagement.service;
 
+import com.raisetech.taskmanagement.dto.CreateTaskRequest;
 import com.raisetech.taskmanagement.entity.Task;
 import com.raisetech.taskmanagement.repository.TaskRepository;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -30,5 +33,28 @@ public class TaskService {
 
     public Optional<Task> findById(Long id) {
         return taskRepository.findById(id);
+    }
+
+    public Task createTask(CreateTaskRequest req) {
+        Task task = new Task();
+        task.setTitle(req.getTitle());
+        task.setDescription(req.getDescription());
+        task.setPriority(req.getPriority());
+        task.setStatus(req.getStatus() != null ? req.getStatus() : "todo");
+        task.setDueDate(req.getDueDate());
+        LocalDateTime now = LocalDateTime.now();
+        task.setCreatedAt(now);
+        task.setUpdatedAt(now);
+        task.setPosition(nextPositionFor(task.getStatus()));
+        return taskRepository.save(task);
+    }
+
+    private Integer nextPositionFor(String status) {
+        return taskRepository.findByStatus(status).stream()
+                .map(Task::getPosition)
+                .filter(Objects::nonNull)
+                .max(Integer::compareTo)
+                .map(p -> p + 1)
+                .orElse(0);
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { fetchTasks } from './api';
 import type { Task } from './types';
 import { BoardColumn } from './components/BoardColumn';
 import { FilterBar } from './components/FilterBar';
+import { TaskCreateModal } from './components/TaskCreateModal';
 import './style.css';
 
 const COLUMNS: { status: string; label: string }[] = [
@@ -16,24 +17,35 @@ export default function App() {
   const [filterPriority, setFilterPriority] = useState('');
   const [tasks, setTasks]                   = useState<Task[]>([]);
   const [error, setError]                   = useState<string | null>(null);
+  const [createOpen, setCreateOpen]         = useState(false);
+  const [refreshKey, setRefreshKey]         = useState(0);
 
   useEffect(() => {
     setError(null);
     fetchTasks({ status: filterStatus, priority: filterPriority })
       .then(setTasks)
       .catch((e: Error) => setError(e.message));
-  }, [filterStatus, filterPriority]);
+  }, [filterStatus, filterPriority, refreshKey]);
 
   return (
     <div className="board-page">
       <header className="header header-solid">
         <h1>タスクボード</h1>
-        <FilterBar
-          status={filterStatus}
-          priority={filterPriority}
-          onStatusChange={setFilterStatus}
-          onPriorityChange={setFilterPriority}
-        />
+        <div className="header-actions">
+          <FilterBar
+            status={filterStatus}
+            priority={filterPriority}
+            onStatusChange={setFilterStatus}
+            onPriorityChange={setFilterPriority}
+          />
+          <button
+            type="button"
+            className="btn btn-primary new-task-btn"
+            onClick={() => setCreateOpen(true)}
+          >
+            ＋ 新規タスク
+          </button>
+        </div>
       </header>
 
       {error && <p style={{ color: '#eb5a46', padding: '1rem' }}>エラー: {error}</p>}
@@ -49,6 +61,12 @@ export default function App() {
           ))}
         </div>
       </div>
+
+      <TaskCreateModal
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => setRefreshKey((k) => k + 1)}
+      />
     </div>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { Task } from './types';
+import type { CreateTaskInput, Task } from './types';
 
 export async function fetchTasks(params: { status?: string; priority?: string } = {}): Promise<Task[]> {
   const query = new URLSearchParams();
@@ -6,5 +6,24 @@ export async function fetchTasks(params: { status?: string; priority?: string } 
   if (params.priority) query.set('priority', params.priority);
   const res = await fetch(`/api/tasks?${query}`);
   if (!res.ok) throw new Error(`API Error: ${res.status}`);
+  return res.json();
+}
+
+export async function createTask(input: CreateTaskInput): Promise<Task> {
+  const res = await fetch('/api/tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null);
+    if (detail?.errors) {
+      const messages = Object.entries(detail.errors as Record<string, string>)
+        .map(([field, msg]) => `${field}: ${msg}`)
+        .join(', ');
+      throw new Error(messages || `Create failed: ${res.status}`);
+    }
+    throw new Error(`Create failed: ${res.status}`);
+  }
   return res.json();
 }

--- a/frontend/src/components/TaskCreateModal.tsx
+++ b/frontend/src/components/TaskCreateModal.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import { createTask } from '../api';
+import type { CreateTaskInput, Priority, Status, Task } from '../types';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (task: Task) => void;
+}
+
+const INITIAL: CreateTaskInput = {
+  title: '',
+  description: '',
+  priority: null,
+  status: 'todo',
+  dueDate: '',
+};
+
+export function TaskCreateModal({ open, onClose, onCreated }: Props) {
+  const [form, setForm] = useState<CreateTaskInput>(INITIAL);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const reset = () => {
+    setForm(INITIAL);
+    setError(null);
+  };
+
+  const handleClose = () => {
+    if (submitting) return;
+    reset();
+    onClose();
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!form.title.trim()) {
+      setError('タイトルは必須です');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const payload: CreateTaskInput = {
+        title: form.title.trim(),
+        description: form.description?.trim() ? form.description.trim() : null,
+        priority: form.priority || null,
+        status: form.status,
+        dueDate: form.dueDate ? form.dueDate : null,
+      };
+      const created = await createTask(payload);
+      onCreated(created);
+      reset();
+      onClose();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={handleClose}>
+      <div className="modal-dialog" onClick={(e) => e.stopPropagation()}>
+        <h2 className="modal-title">新規タスクの登録</h2>
+        <form onSubmit={handleSubmit} className="modal-form">
+          <label className="modal-field">
+            <span>タイトル<span className="required">*</span></span>
+            <input
+              type="text"
+              value={form.title}
+              onChange={(e) => setForm({ ...form, title: e.target.value })}
+              autoFocus
+              maxLength={200}
+            />
+          </label>
+
+          <label className="modal-field">
+            <span>説明</span>
+            <textarea
+              value={form.description ?? ''}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              rows={3}
+            />
+          </label>
+
+          <div className="modal-row">
+            <label className="modal-field">
+              <span>優先度</span>
+              <select
+                value={form.priority ?? ''}
+                onChange={(e) =>
+                  setForm({ ...form, priority: (e.target.value || null) as Priority | null })
+                }
+              >
+                <option value="">未設定</option>
+                <option value="high">高</option>
+                <option value="medium">中</option>
+                <option value="low">低</option>
+              </select>
+            </label>
+
+            <label className="modal-field">
+              <span>ステータス</span>
+              <select
+                value={form.status ?? 'todo'}
+                onChange={(e) => setForm({ ...form, status: e.target.value as Status })}
+              >
+                <option value="todo">未着手</option>
+                <option value="doing">進行中</option>
+                <option value="done">完了</option>
+              </select>
+            </label>
+
+            <label className="modal-field">
+              <span>期限</span>
+              <input
+                type="date"
+                value={form.dueDate ?? ''}
+                onChange={(e) => setForm({ ...form, dueDate: e.target.value })}
+              />
+            </label>
+          </div>
+
+          {error && <p className="modal-error">{error}</p>}
+
+          <div className="modal-actions">
+            <button type="button" onClick={handleClose} disabled={submitting} className="btn btn-secondary">
+              キャンセル
+            </button>
+            <button type="submit" disabled={submitting} className="btn btn-primary">
+              {submitting ? '登録中…' : '登録'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -194,3 +194,150 @@ body {
   background: #61bd4f;
   color: #fff;
 }
+
+/* ==== Header actions ==== */
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* ==== Buttons ==== */
+.btn {
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.85rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: #5aac44;
+  color: #fff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #519839;
+}
+
+.btn-secondary {
+  background: #ebecf0;
+  color: #172b4d;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: #dcdfe4;
+}
+
+.new-task-btn {
+  white-space: nowrap;
+}
+
+/* ==== Modal ==== */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.modal-dialog {
+  background: #fff;
+  border-radius: 6px;
+  width: 100%;
+  max-width: 520px;
+  padding: 1.25rem 1.5rem 1.5rem;
+  box-shadow: 0 12px 32px rgba(9, 30, 66, 0.4);
+}
+
+.modal-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #172b4d;
+}
+
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  color: #5e6c84;
+}
+
+.modal-field span {
+  font-weight: 600;
+}
+
+.modal-field .required {
+  color: #eb5a46;
+  margin-left: 0.2rem;
+}
+
+.modal-field input,
+.modal-field textarea,
+.modal-field select {
+  font-size: 0.9rem;
+  font-family: inherit;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid #dfe1e6;
+  border-radius: 4px;
+  background: #fafbfc;
+  color: #172b4d;
+  outline: none;
+}
+
+.modal-field input:focus,
+.modal-field textarea:focus,
+.modal-field select:focus {
+  border-color: #0079bf;
+  background: #fff;
+}
+
+.modal-field textarea {
+  resize: vertical;
+  min-height: 64px;
+}
+
+.modal-row {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.modal-row .modal-field {
+  flex: 1 1 0;
+  min-width: 120px;
+}
+
+.modal-error {
+  background: #ffebe6;
+  color: #bf2600;
+  padding: 0.5rem 0.7rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,3 +12,11 @@ export interface Task {
   createdAt: string | null;
   updatedAt: string | null;
 }
+
+export interface CreateTaskInput {
+  title: string;
+  description?: string | null;
+  priority?: Priority | null;
+  status?: Status;
+  dueDate?: string | null;
+}


### PR DESCRIPTION
Closes #7

## 概要
タスクのCreate（登録）処理をバックエンド・フロントエンド両方で実装。

## 変更内容

### バックエンド
- `POST /api/tasks` エンドポイントを追加
- `CreateTaskRequest` DTO を導入（Entityへの直接バインドを回避し、id/createdAt等を分離）
- `@NotBlank` で title 必須を検証、`@Valid` で自動チェック
- `GlobalExceptionHandler` を追加し、バリデーションエラーは 400 + `{ message, errors: { field: msg } }` 形式で返却
- CORS設定で POST を許可
- `spring-boot-starter-validation` 依存を追加

### フロントエンド
- ボード画面右上に「＋ 新規タスク」ボタンを追加
- `TaskCreateModal` コンポーネントを新規作成
  - 入力項目: タイトル（必須）/ 説明 / 優先度 / ステータス / 期限
  - クライアント側でも title 空チェック
  - サーバーのバリデーションエラーをモーダル内に表示
- 登録成功時は `refreshKey` をインクリメントしてボード再取得で即時反映
- モーダル用のスタイル（オーバーレイ・ダイアログ・フォーム）を `style.css` に追加

## 動作確認

### API レベル（✅ 完了）
```
# 正常系: 201 Created
$ curl -i -X POST http://localhost:8080/api/tasks \
    -H 'Content-Type: application/json' \
    -d '{"title":"テスト","priority":"low","status":"todo"}'
HTTP/1.1 201
{"id":8, "title":"テスト", ..., "position":8, "createdAt":"..."}

# 異常系: 400 Bad Request
$ curl -i -X POST http://localhost:8080/api/tasks \
    -H 'Content-Type: application/json' \
    -d '{"title":""}'
HTTP/1.1 400
{"message":"リクエストが不正です","errors":{"title":"title は必須です"}}

# DB 確認
$ docker compose exec db psql -U taskmanagement -d taskmanagement \
    -c "SELECT id, title, created_at FROM tasks ORDER BY id DESC LIMIT 1;"
→ 登録レコードが永続化されていることを確認
```

Vite proxy 経由（`http://localhost:5173/api/tasks`）でも 201 を確認済み。

### UI レベル（要手動確認）
- [ ] http://localhost:5173 で「＋ 新規タスク」ボタン押下 → モーダル表示
- [ ] フォームに入力して登録 → ボードに新カードが現れる
- [ ] title 空のまま送信 → 赤いエラー表示が出て登録されない