### PR TITLE
feat: タスク更新APIと編集UIを追加 (#9)

### DIFF
--- a/backend/src/main/java/com/raisetech/taskmanagement/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/config/WebMvcConfig.java
@@ -11,6 +11,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
                 .allowedOrigins("http://localhost:5173")
-                .allowedMethods("GET", "POST");
+                .allowedMethods("GET", "POST", "PATCH");
     }
 }

--- a/backend/src/main/java/com/raisetech/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/controller/TaskController.java
@@ -1,12 +1,14 @@
 package com.raisetech.taskmanagement.controller;
 
 import com.raisetech.taskmanagement.dto.CreateTaskRequest;
+import com.raisetech.taskmanagement.dto.UpdateTaskRequest;
 import com.raisetech.taskmanagement.entity.Task;
 import com.raisetech.taskmanagement.service.TaskService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,5 +46,12 @@ public class TaskController {
     public ResponseEntity<Task> createTask(@Valid @RequestBody CreateTaskRequest request) {
         Task created = taskService.createTask(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Task> updateTask(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateTaskRequest request) {
+        return ResponseEntity.ok(taskService.updateTask(id, request));
     }
 }

--- a/backend/src/main/java/com/raisetech/taskmanagement/dto/UpdateTaskRequest.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/dto/UpdateTaskRequest.java
@@ -1,0 +1,68 @@
+package com.raisetech.taskmanagement.dto;
+
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public class UpdateTaskRequest {
+
+    @Size(min = 1, message = "title は空にできません")
+    private String title;
+
+    private String description;
+
+    private String priority;
+
+    private String status;
+
+    private LocalDate dueDate;
+
+    private Integer position;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public Integer getPosition() {
+        return position;
+    }
+
+    public void setPosition(Integer position) {
+        this.position = position;
+    }
+}

--- a/backend/src/main/java/com/raisetech/taskmanagement/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/exception/GlobalExceptionHandler.java
@@ -24,4 +24,11 @@ public class GlobalExceptionHandler {
         body.put("errors", fieldErrors);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleNotFound(NotFoundException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
 }

--- a/backend/src/main/java/com/raisetech/taskmanagement/exception/NotFoundException.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.raisetech.taskmanagement.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/raisetech/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/service/TaskService.java
@@ -70,17 +70,13 @@ public class TaskService {
         }
         if (req.getDueDate() != null) task.setDueDate(req.getDueDate());
         if (req.getPosition() != null) {
-            task.setPosition(req.getPosition());
             orderChanged = true;
         }
         task.setUpdatedAt(LocalDateTime.now());
         taskRepository.save(task);
 
         if (orderChanged) {
-            normalizeColumn(oldStatus);
-            if (!Objects.equals(oldStatus, task.getStatus())) {
-                normalizeColumn(task.getStatus());
-            }
+            reorderWithMove(task, oldStatus, req.getPosition());
         }
         return taskRepository.findById(id).orElseThrow();
     }
@@ -94,17 +90,35 @@ public class TaskService {
                 .orElse(0);
     }
 
-    private void normalizeColumn(String status) {
-        if (status == null) return;
+    private List<Task> getSortedColumn(String status) {
         List<Task> col = taskRepository.findByStatus(status);
-        col.sort(Comparator
-                .comparing((Task t) -> t.getPosition() == null ? Integer.MAX_VALUE : t.getPosition())
-                .thenComparing(Task::getId));
-        for (int i = 0; i < col.size(); i++) {
-            if (!Integer.valueOf(i).equals(col.get(i).getPosition())) {
-                col.get(i).setPosition(i);
-            }
+        col.sort(Comparator.comparingInt(t -> t.getPosition() == null ? Integer.MAX_VALUE : t.getPosition()));
+        return col;
+    }
+
+    private void reorderWithMove(Task movedTask, String oldStatus, Integer targetIndex) {
+        String newStatus = movedTask.getStatus();
+        boolean crossColumn = !oldStatus.equals(newStatus);
+
+        List<Task> sourceCol = getSortedColumn(oldStatus);
+        sourceCol.removeIf(t -> t.getId().equals(movedTask.getId()));
+
+        List<Task> targetCol = crossColumn ? getSortedColumn(newStatus) : sourceCol;
+
+        int insertAt = (targetIndex == null) ? targetCol.size()
+                : Math.min(targetIndex, targetCol.size());
+        targetCol.add(insertAt, movedTask);
+
+        for (int i = 0; i < targetCol.size(); i++) {
+            targetCol.get(i).setPosition(i);
         }
-        taskRepository.saveAll(col);
+        taskRepository.saveAll(targetCol);
+
+        if (crossColumn) {
+            for (int i = 0; i < sourceCol.size(); i++) {
+                sourceCol.get(i).setPosition(i);
+            }
+            taskRepository.saveAll(sourceCol);
+        }
     }
 }

--- a/backend/src/main/java/com/raisetech/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/service/TaskService.java
@@ -1,11 +1,15 @@
 package com.raisetech.taskmanagement.service;
 
 import com.raisetech.taskmanagement.dto.CreateTaskRequest;
+import com.raisetech.taskmanagement.dto.UpdateTaskRequest;
 import com.raisetech.taskmanagement.entity.Task;
+import com.raisetech.taskmanagement.exception.NotFoundException;
 import com.raisetech.taskmanagement.repository.TaskRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -49,6 +53,38 @@ public class TaskService {
         return taskRepository.save(task);
     }
 
+    @Transactional
+    public Task updateTask(Long id, UpdateTaskRequest req) {
+        Task task = taskRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Task not found: " + id));
+
+        String oldStatus = task.getStatus();
+        boolean orderChanged = false;
+
+        if (req.getTitle() != null) task.setTitle(req.getTitle());
+        if (req.getDescription() != null) task.setDescription(req.getDescription());
+        if (req.getPriority() != null) task.setPriority(req.getPriority());
+        if (req.getStatus() != null) {
+            if (!req.getStatus().equals(oldStatus)) orderChanged = true;
+            task.setStatus(req.getStatus());
+        }
+        if (req.getDueDate() != null) task.setDueDate(req.getDueDate());
+        if (req.getPosition() != null) {
+            task.setPosition(req.getPosition());
+            orderChanged = true;
+        }
+        task.setUpdatedAt(LocalDateTime.now());
+        taskRepository.save(task);
+
+        if (orderChanged) {
+            normalizeColumn(oldStatus);
+            if (!Objects.equals(oldStatus, task.getStatus())) {
+                normalizeColumn(task.getStatus());
+            }
+        }
+        return taskRepository.findById(id).orElseThrow();
+    }
+
     private Integer nextPositionFor(String status) {
         return taskRepository.findByStatus(status).stream()
                 .map(Task::getPosition)
@@ -56,5 +92,19 @@ public class TaskService {
                 .max(Integer::compareTo)
                 .map(p -> p + 1)
                 .orElse(0);
+    }
+
+    private void normalizeColumn(String status) {
+        if (status == null) return;
+        List<Task> col = taskRepository.findByStatus(status);
+        col.sort(Comparator
+                .comparing((Task t) -> t.getPosition() == null ? Integer.MAX_VALUE : t.getPosition())
+                .thenComparing(Task::getId));
+        for (int i = 0; i < col.size(); i++) {
+            if (!Integer.valueOf(i).equals(col.get(i).getPosition())) {
+                col.get(i).setPosition(i);
+            }
+        }
+        taskRepository.saveAll(col);
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
-import { fetchTasks } from './api';
-import type { Task } from './types';
+import { fetchTasks, updateTask } from './api';
+import type { Status, Task } from './types';
 import { BoardColumn } from './components/BoardColumn';
 import { FilterBar } from './components/FilterBar';
 import { TaskCreateModal } from './components/TaskCreateModal';
+import { TaskEditModal } from './components/TaskEditModal';
 import './style.css';
 
-const COLUMNS: { status: string; label: string }[] = [
+const COLUMNS: { status: Status; label: string }[] = [
   { status: 'todo',  label: '未着手' },
   { status: 'doing', label: '進行中' },
   { status: 'done',  label: '完了' },
@@ -18,6 +19,8 @@ export default function App() {
   const [tasks, setTasks]                   = useState<Task[]>([]);
   const [error, setError]                   = useState<string | null>(null);
   const [createOpen, setCreateOpen]         = useState(false);
+  const [editingTask, setEditingTask]       = useState<Task | null>(null);
+  const [draggingId, setDraggingId]         = useState<number | null>(null);
   const [refreshKey, setRefreshKey]         = useState(0);
 
   useEffect(() => {
@@ -26,6 +29,24 @@ export default function App() {
       .then(setTasks)
       .catch((e: Error) => setError(e.message));
   }, [filterStatus, filterPriority, refreshKey]);
+
+  const tasksByColumn = (status: Status): Task[] =>
+    tasks
+      .filter((t) => t.status === status)
+      .sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+
+  const handleDrop = async (taskId: number, targetStatus: Status, targetIndex: number) => {
+    const original = tasks.find((t) => t.id === taskId);
+    if (!original) return;
+    if (original.status === targetStatus && original.position === targetIndex) return;
+
+    try {
+      await updateTask(taskId, { status: targetStatus, position: targetIndex });
+      setRefreshKey((k) => k + 1);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  };
 
   return (
     <div className="board-page">
@@ -55,8 +76,14 @@ export default function App() {
           {COLUMNS.map(({ status, label }) => (
             <BoardColumn
               key={status}
+              status={status}
               title={label}
-              tasks={tasks.filter((t) => t.status === status)}
+              tasks={tasksByColumn(status)}
+              draggingId={draggingId}
+              onEdit={setEditingTask}
+              onDragStart={(task) => setDraggingId(task.id)}
+              onDragEnd={() => setDraggingId(null)}
+              onDrop={handleDrop}
             />
           ))}
         </div>
@@ -66,6 +93,12 @@ export default function App() {
         open={createOpen}
         onClose={() => setCreateOpen(false)}
         onCreated={() => setRefreshKey((k) => k + 1)}
+      />
+
+      <TaskEditModal
+        task={editingTask}
+        onClose={() => setEditingTask(null)}
+        onSaved={() => setRefreshKey((k) => k + 1)}
       />
     </div>
   );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,18 @@
-import type { CreateTaskInput, Task } from './types';
+import type { CreateTaskInput, Task, UpdateTaskInput } from './types';
+
+async function parseApiError(res: Response, fallback: string): Promise<Error> {
+  const detail = await res.json().catch(() => null);
+  if (detail?.errors) {
+    const messages = Object.entries(detail.errors as Record<string, string>)
+      .map(([field, msg]) => `${field}: ${msg}`)
+      .join(', ');
+    return new Error(messages || fallback);
+  }
+  if (detail?.message) {
+    return new Error(detail.message);
+  }
+  return new Error(fallback);
+}
 
 export async function fetchTasks(params: { status?: string; priority?: string } = {}): Promise<Task[]> {
   const query = new URLSearchParams();
@@ -15,15 +29,16 @@ export async function createTask(input: CreateTaskInput): Promise<Task> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(input),
   });
-  if (!res.ok) {
-    const detail = await res.json().catch(() => null);
-    if (detail?.errors) {
-      const messages = Object.entries(detail.errors as Record<string, string>)
-        .map(([field, msg]) => `${field}: ${msg}`)
-        .join(', ');
-      throw new Error(messages || `Create failed: ${res.status}`);
-    }
-    throw new Error(`Create failed: ${res.status}`);
-  }
+  if (!res.ok) throw await parseApiError(res, `Create failed: ${res.status}`);
+  return res.json();
+}
+
+export async function updateTask(id: number, input: UpdateTaskInput): Promise<Task> {
+  const res = await fetch(`/api/tasks/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) throw await parseApiError(res, `Update failed: ${res.status}`);
   return res.json();
 }

--- a/frontend/src/components/BoardColumn.tsx
+++ b/frontend/src/components/BoardColumn.tsx
@@ -1,23 +1,88 @@
-import type { Task } from '../types';
+import { useState, useRef } from 'react';
+import type { Status, Task } from '../types';
 import { TaskCard } from './TaskCard';
 
 interface Props {
+  status: Status;
   title: string;
   tasks: Task[];
+  draggingId: number | null;
+  onEdit: (task: Task) => void;
+  onDragStart: (task: Task) => void;
+  onDragEnd: () => void;
+  onDrop: (taskId: number, targetStatus: Status, targetIndex: number) => void;
 }
 
-export function BoardColumn({ title, tasks }: Props) {
+export function BoardColumn({
+  status,
+  title,
+  tasks,
+  draggingId,
+  onEdit,
+  onDragStart,
+  onDragEnd,
+  onDrop,
+}: Props) {
+  const [hover, setHover] = useState(false);
+  const cardsRef = useRef<HTMLDivElement | null>(null);
+
+  const computeTargetIndex = (clientY: number): number => {
+    const container = cardsRef.current;
+    if (!container) return tasks.length;
+    const cardEls = Array.from(container.querySelectorAll<HTMLElement>('.card'));
+    for (let i = 0; i < cardEls.length; i++) {
+      const rect = cardEls[i].getBoundingClientRect();
+      if (clientY < rect.top + rect.height / 2) return i;
+    }
+    return cardEls.length;
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setHover(false);
+    const idStr = e.dataTransfer.getData('text/plain');
+    const taskId = Number(idStr);
+    if (!taskId) return;
+
+    let targetIndex = computeTargetIndex(e.clientY);
+    // Same-column move: account for the dragged card being removed from its current position
+    const draggedIndexInColumn = tasks.findIndex((t) => t.id === taskId);
+    if (draggedIndexInColumn !== -1 && targetIndex > draggedIndexInColumn) {
+      targetIndex -= 1;
+    }
+    onDrop(taskId, status, targetIndex);
+  };
+
   return (
-    <div className="list">
+    <div
+      className={['list', hover ? 'drag-hover' : ''].filter(Boolean).join(' ')}
+      onDragOver={(e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        if (!hover) setHover(true);
+      }}
+      onDragLeave={(e) => {
+        // Only clear hover when leaving the list element itself, not its children
+        if (e.currentTarget === e.target) setHover(false);
+      }}
+      onDrop={handleDrop}
+    >
       <div className="list-header">
         <h2>
           {title}
           <span className="list-count">{tasks.length}</span>
         </h2>
       </div>
-      <div className="cards">
+      <div className="cards" ref={cardsRef}>
         {tasks.map((task) => (
-          <TaskCard key={task.id} task={task} />
+          <TaskCard
+            key={task.id}
+            task={task}
+            isDragging={draggingId === task.id}
+            onEdit={onEdit}
+            onDragStart={onDragStart}
+            onDragEnd={onDragEnd}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -25,14 +25,29 @@ function formatDueDate(dateStr: string): string {
 
 interface Props {
   task: Task;
+  isDragging?: boolean;
+  onEdit?: (task: Task) => void;
+  onDragStart?: (task: Task) => void;
+  onDragEnd?: () => void;
 }
 
-export function TaskCard({ task }: Props) {
+export function TaskCard({ task, isDragging, onEdit, onDragStart, onDragEnd }: Props) {
   const priority = task.priority ? PRIORITY_MAP[task.priority] : null;
   const dueStatus = task.dueDate ? dueDateStatus(task.dueDate) : null;
 
   return (
-    <div className="card">
+    <div
+      className={['card', isDragging ? 'dragging' : ''].filter(Boolean).join(' ')}
+      draggable
+      data-task-id={task.id}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/plain', String(task.id));
+        e.dataTransfer.effectAllowed = 'move';
+        onDragStart?.(task);
+      }}
+      onDragEnd={() => onDragEnd?.()}
+      onClick={() => onEdit?.(task)}
+    >
       {priority && (
         <span className="card-priority" style={{ background: priority.color }}>
           {priority.label}

--- a/frontend/src/components/TaskEditModal.tsx
+++ b/frontend/src/components/TaskEditModal.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react';
+import { updateTask } from '../api';
+import type { Priority, Status, Task, UpdateTaskInput } from '../types';
+
+interface Props {
+  task: Task | null;
+  onClose: () => void;
+  onSaved: (task: Task) => void;
+}
+
+interface FormState {
+  title: string;
+  description: string;
+  priority: Priority | '';
+  status: Status;
+  dueDate: string;
+}
+
+function toFormState(task: Task): FormState {
+  return {
+    title: task.title,
+    description: task.description ?? '',
+    priority: (task.priority ?? '') as Priority | '',
+    status: (task.status ?? 'todo') as Status,
+    dueDate: task.dueDate ?? '',
+  };
+}
+
+export function TaskEditModal({ task, onClose, onSaved }: Props) {
+  const [form, setForm] = useState<FormState | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (task) {
+      setForm(toFormState(task));
+      setError(null);
+    } else {
+      setForm(null);
+    }
+  }, [task]);
+
+  if (!task || !form) return null;
+
+  const handleClose = () => {
+    if (submitting) return;
+    onClose();
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!form.title.trim()) {
+      setError('タイトルは必須です');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const payload: UpdateTaskInput = {
+        title: form.title.trim(),
+        description: form.description.trim() ? form.description.trim() : null,
+        priority: form.priority || null,
+        status: form.status,
+        dueDate: form.dueDate ? form.dueDate : null,
+      };
+      const saved = await updateTask(task.id, payload);
+      onSaved(saved);
+      onClose();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={handleClose}>
+      <div className="modal-dialog" onClick={(e) => e.stopPropagation()}>
+        <h2 className="modal-title">タスクの編集</h2>
+        <form onSubmit={handleSubmit} className="modal-form">
+          <label className="modal-field">
+            <span>タイトル<span className="required">*</span></span>
+            <input
+              type="text"
+              value={form.title}
+              onChange={(e) => setForm({ ...form, title: e.target.value })}
+              autoFocus
+              maxLength={200}
+            />
+          </label>
+
+          <label className="modal-field">
+            <span>説明</span>
+            <textarea
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              rows={3}
+            />
+          </label>
+
+          <div className="modal-row">
+            <label className="modal-field">
+              <span>優先度</span>
+              <select
+                value={form.priority}
+                onChange={(e) =>
+                  setForm({ ...form, priority: e.target.value as Priority | '' })
+                }
+              >
+                <option value="">未設定</option>
+                <option value="high">高</option>
+                <option value="medium">中</option>
+                <option value="low">低</option>
+              </select>
+            </label>
+
+            <label className="modal-field">
+              <span>ステータス</span>
+              <select
+                value={form.status}
+                onChange={(e) => setForm({ ...form, status: e.target.value as Status })}
+              >
+                <option value="todo">未着手</option>
+                <option value="doing">進行中</option>
+                <option value="done">完了</option>
+              </select>
+            </label>
+
+            <label className="modal-field">
+              <span>期限</span>
+              <input
+                type="date"
+                value={form.dueDate}
+                onChange={(e) => setForm({ ...form, dueDate: e.target.value })}
+              />
+            </label>
+          </div>
+
+          {error && <p className="modal-error">{error}</p>}
+
+          <div className="modal-actions">
+            <button
+              type="button"
+              onClick={handleClose}
+              disabled={submitting}
+              className="btn btn-secondary"
+            >
+              キャンセル
+            </button>
+            <button type="submit" disabled={submitting} className="btn btn-primary">
+              {submitting ? '保存中…' : '保存'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -134,11 +134,25 @@ body {
   box-shadow: 0 1px 0 rgba(9, 30, 66, 0.25);
   font-size: 0.9rem;
   word-break: break-word;
+  cursor: grab;
+  user-select: none;
+}
+
+.card:active {
+  cursor: grabbing;
+}
+
+.card.dragging {
+  opacity: 0.4;
 }
 
 .card:hover {
   background: #fafbfc;
   box-shadow: 0 1px 0 rgba(9, 30, 66, 0.35);
+}
+
+.list.drag-hover {
+  background: #d4dae3;
 }
 
 /* ==== Card priority badge ==== */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,3 +20,12 @@ export interface CreateTaskInput {
   status?: Status;
   dueDate?: string | null;
 }
+
+export interface UpdateTaskInput {
+  title?: string;
+  description?: string | null;
+  priority?: Priority | null;
+  status?: Status;
+  dueDate?: string | null;
+  position?: number;
+}


### PR DESCRIPTION
Closes #9

## 概要
タスクのUpdate（更新）処理をバックエンド・フロントエンド両方で実装。
PATCH（部分更新）API + カードクリックの編集モーダル + HTML5 D&D の並び替えに対応。

## 変更内容

### バックエンド
- `PATCH /api/tasks/{id}` を追加（部分更新）
- `UpdateTaskRequest` DTO を導入
  - 全フィールドオプショナル、`null` は「変更しない」
  - `title` は `@Size(min=1)` で空文字不可
- `TaskService#updateTask`
  - status / position が変わったとき、影響カラムを `0..N-1` に再採番（`normalizeColumn`）
  - `@Transactional` で一連の更新を1トランザクションに
- 不在 id は `NotFoundException` → `GlobalExceptionHandler` で 404 返却
- CORS で PATCH を許可

### フロントエンド
- `TaskEditModal` を新規追加：カードクリックで開き、全項目を編集して保存
- `TaskCard`：`draggable` 属性 + `onDragStart`/`onDragEnd` を追加（外部ライブラリなし、HTML5 標準 API のみ使用）
- `BoardColumn`：ドロップターゲット化
  - `onDragOver` で `preventDefault()` してドロップ許可
  - cursor Y 座標と各カードの bounding rect から target index を計算
  - 同カラム内ドラッグの場合、自分の元位置分を index から控除
- `api.ts`：エラー整形を `parseApiError` に集約して `createTask` / `updateTask` で共通化
- `App.tsx`：ドラッグ状態（`draggingId`）と編集対象（`editingTask`）を統合管理。同カラム内のカードは `position` 昇順で表示

## 動作確認

### API レベル（✅ 完了）
```
# 部分更新（priority だけ）
$ curl -i -X PATCH http://localhost:8080/api/tasks/1 \
    -H 'Content-Type: application/json' -d '{"priority":"low"}'
HTTP/1.1 200 → 他フィールドは保持、priority のみ更新

# カラム間移動（status + position）
$ curl -i -X PATCH http://localhost:8080/api/tasks/1 \
    -H 'Content-Type: application/json' -d '{"status":"done","position":0}'
HTTP/1.1 200 → DB 上で done カラムが 0..N-1 に正規化される

# 不在 id
HTTP/1.1 404 {"message":"Task not found: 99999"}

# title 空指定
HTTP/1.1 400 {"errors":{"title":"title は空にできません"}}
```

Vite proxy 経由（`http://localhost:5173/api/tasks/1`）でも 200 を確認済み。

### UI レベル（要手動確認）
- [ ] http://localhost:5173 でカードをクリック → 編集モーダルが開き、現在の値がプリフィル
- [ ] title 変更して保存 → ボード即時反映
- [ ] title 空のまま保存 → 赤枠でエラー表示
- [ ] カードを別カラムにドラッグ → ステータスが変わり、進行中カラムに移動
- [ ] 同カラム内で上下にドラッグ → 順序が入れ替わり、リロード後も保たれる