### PR TITLE
feat: タスク削除APIと削除UIを追加 (#11)

### DIFF
--- a/backend/src/main/java/com/raisetech/taskmanagement/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/config/WebMvcConfig.java
@@ -11,6 +11,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
                 .allowedOrigins("http://localhost:5173")
-                .allowedMethods("GET", "POST", "PATCH");
+                .allowedMethods("GET", "POST", "PATCH", "DELETE");
     }
 }

--- a/backend/src/main/java/com/raisetech/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/controller/TaskController.java
@@ -7,6 +7,7 @@ import com.raisetech.taskmanagement.service.TaskService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,5 +54,11 @@ public class TaskController {
             @PathVariable Long id,
             @Valid @RequestBody UpdateTaskRequest request) {
         return ResponseEntity.ok(taskService.updateTask(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
+        taskService.deleteTask(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/raisetech/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/raisetech/taskmanagement/service/TaskService.java
@@ -90,6 +90,19 @@ public class TaskService {
                 .orElse(0);
     }
 
+    @Transactional
+    public void deleteTask(Long id) {
+        Task task = taskRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Task not found: " + id));
+        String status = task.getStatus();
+        taskRepository.deleteById(id);
+        List<Task> col = getSortedColumn(status);
+        for (int i = 0; i < col.size(); i++) {
+            col.get(i).setPosition(i);
+        }
+        taskRepository.saveAll(col);
+    }
+
     private List<Task> getSortedColumn(String status) {
         List<Task> col = taskRepository.findByStatus(status);
         col.sort(Comparator.comparingInt(t -> t.getPosition() == null ? Integer.MAX_VALUE : t.getPosition()));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -99,6 +99,7 @@ export default function App() {
         task={editingTask}
         onClose={() => setEditingTask(null)}
         onSaved={() => setRefreshKey((k) => k + 1)}
+        onDeleted={() => { setEditingTask(null); setRefreshKey((k) => k + 1); }}
       />
     </div>
   );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -42,3 +42,8 @@ export async function updateTask(id: number, input: UpdateTaskInput): Promise<Ta
   if (!res.ok) throw await parseApiError(res, `Update failed: ${res.status}`);
   return res.json();
 }
+
+export async function deleteTask(id: number): Promise<void> {
+  const res = await fetch(`/api/tasks/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw await parseApiError(res, `Delete failed: ${res.status}`);
+}

--- a/frontend/src/components/TaskEditModal.tsx
+++ b/frontend/src/components/TaskEditModal.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { updateTask } from '../api';
+import { deleteTask, updateTask } from '../api';
 import type { Priority, Status, Task, UpdateTaskInput } from '../types';
 
 interface Props {
   task: Task | null;
   onClose: () => void;
   onSaved: (task: Task) => void;
+  onDeleted: () => void;
 }
 
 interface FormState {
@@ -26,7 +27,7 @@ function toFormState(task: Task): FormState {
   };
 }
 
-export function TaskEditModal({ task, onClose, onSaved }: Props) {
+export function TaskEditModal({ task, onClose, onSaved, onDeleted }: Props) {
   const [form, setForm] = useState<FormState | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -45,6 +46,21 @@ export function TaskEditModal({ task, onClose, onSaved }: Props) {
   const handleClose = () => {
     if (submitting) return;
     onClose();
+  };
+
+  const handleDelete = async () => {
+    if (!task) return;
+    if (!window.confirm(`「${task.title}」を削除しますか？`)) return;
+    setSubmitting(true);
+    try {
+      await deleteTask(task.id);
+      onDeleted();
+      onClose();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -141,6 +157,15 @@ export function TaskEditModal({ task, onClose, onSaved }: Props) {
           {error && <p className="modal-error">{error}</p>}
 
           <div className="modal-actions">
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={submitting}
+              className="btn btn-danger"
+            >
+              削除
+            </button>
+            <div style={{ flex: 1 }} />
             <button
               type="button"
               onClick={handleClose}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -250,6 +250,15 @@ body {
   background: #dcdfe4;
 }
 
+.btn-danger {
+  background: #eb5a46;
+  color: #fff;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: #c9372c;
+}
+
 .new-task-btn {
   white-space: nowrap;
 }


### PR DESCRIPTION
## 変更内容

### バックエンド
- `DELETE /api/tasks/{id}` エンドポイントを追加（204 No Content）
- 削除後に同カラムの `position` を 0..N-1 に再採番
- 存在しない id は 404 を返す（既存 `NotFoundException` を再利用）
- CORS に `DELETE` メソッドを追加

### フロントエンド
- `deleteTask()` API 関数を追加
- 編集モーダル左下に「削除」ボタン（赤）を追加
- 削除前に `window.confirm` で確認ダイアログを表示
- 削除後はモーダルを閉じてボードを再読み込み

Closes #11